### PR TITLE
enhance condense metric

### DIFF
--- a/R/tbl-metric.R
+++ b/R/tbl-metric.R
@@ -116,12 +116,12 @@ condense_metric <- function(metric, max_dimensions = 2) {
   v <- get_filter_dimensions(metric)
   if (length(v) > 0){
     ret <- metric %>%
-      group_by_at(v) %>%
-      group_nest() %>%
-      mutate(data = map(
+      dplyr::group_by_at(v) %>%
+      dplyr::group_nest() %>%
+      dplyr::mutate(data = map(
         data, condense_metric, max_dimensions = max_dimensions)
       ) %>%
-      unnest()
+      tidyr::unnest()
 
   } else {
     dims <- var_names_dimensions(metric)


### PR DESCRIPTION
This PR supports cases where there are dimensions which only act as filters, and don't have an "All" level. In such cases, condense_metric usually returns NAs as it does not find "All". The fix here checks if there are such dimensions, and if so, uses a group, nest, and mutate strategy to condense the metric.